### PR TITLE
setting up http-proxy-middleware

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -12,6 +12,7 @@
         "@types/react-dom": "^16.9.0",
         "@types/styled-components": "^5.1.3",
         "antd": "^4.6.4",
+        "http-proxy-middleware": "^1.0.5",
         "i18next": "^19.7.0",
         "i18next-browser-languagedetector": "^6.0.1",
         "react": "^16.13.1",

--- a/packages/frontend/src/hooks/useAvailableCountries.ts
+++ b/packages/frontend/src/hooks/useAvailableCountries.ts
@@ -1,9 +1,7 @@
 import { useQuery } from 'react-query';
 
 const getAvailableCountries = async () => {
-    const request = await fetch(
-        `${process.env.REACT_APP_API_LOCATION}/country/`
-    );
+    const request = await fetch('api/country/');
     const result = await request.json();
     return result;
 };

--- a/packages/frontend/src/hooks/useCountryStats.ts
+++ b/packages/frontend/src/hooks/useCountryStats.ts
@@ -1,9 +1,7 @@
 import { useQuery } from 'react-query';
 
 const getCountryStats = async (_: any, country: string | undefined) => {
-    const request = await fetch(
-        `${process.env.REACT_APP_API_LOCATION}/country/${country}/stats`
-    );
+    const request = await fetch(`api/country/${country}/stats`);
     const result = await request.json();
     return result;
 };

--- a/packages/frontend/src/hooks/useCountryTrends.ts
+++ b/packages/frontend/src/hooks/useCountryTrends.ts
@@ -1,9 +1,7 @@
 import { useQuery } from 'react-query';
 
 const getTrendForCountry = async (_: any, country: string | undefined) => {
-    const request = await fetch(
-        `${process.env.REACT_APP_API_LOCATION}/country/${country}/trends`
-    );
+    const request = await fetch(`api/country/${country}/trends`);
     const result = await request.json();
     return result;
 };

--- a/packages/frontend/src/setupProxy.js
+++ b/packages/frontend/src/setupProxy.js
@@ -1,0 +1,14 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+module.exports = function(app) {
+    app.use(
+        '/api',
+        createProxyMiddleware({
+            target: 'http://localhost:4000',
+            changeOrigin: true,
+            pathRewrite: {
+                '^/api/': '/'
+            }
+        })
+    );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2997,6 +2997,13 @@
     "@types/react" "*"
     hoist-non-react-statics "^3.3.0"
 
+"@types/http-proxy@^1.17.4":
+  version "1.17.4"
+  resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.4.tgz#e7c92e3dbe3e13aa799440ff42e6d3a17a9d045b"
+  integrity sha512-IrSHl2u6AWXduUaDLqYpt45tLVCtYv7o4Z0s1KghBCDgIIS9oW5K1H8mZG/A2CfeLdEa7rTd1ACOiHBc1EMT2Q==
+  dependencies:
+    "@types/node" "*"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
@@ -8326,7 +8333,18 @@ http-proxy-middleware@0.19.1:
     lodash "^4.17.11"
     micromatch "^3.1.10"
 
-http-proxy@^1.17.0:
+http-proxy-middleware@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-1.0.5.tgz#4c6e25d95a411e3d750bc79ccf66290675176dc2"
+  integrity sha512-CKzML7u4RdGob8wuKI//H8Ein6wNTEQR7yjVEzPbhBLGdOfkfvgTnp2HLnniKBDP9QW4eG10/724iTWLBeER3g==
+  dependencies:
+    "@types/http-proxy" "^1.17.4"
+    http-proxy "^1.18.1"
+    is-glob "^4.0.1"
+    lodash "^4.17.19"
+    micromatch "^4.0.2"
+
+http-proxy@^1.17.0, http-proxy@^1.18.1:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
   integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==


### PR DESCRIPTION
This moves from using an environment variable to specify the API host to using http-proxy-middleware 