### PR TITLE
Setting to tell CI to ignore warnings so builds don't fail

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -26,7 +26,7 @@
     },
     "scripts": {
         "start": "react-scripts start",
-        "build": "react-scripts build",
+        "build": "CI=\"\" react-scripts build",
         "test": "react-scripts test",
         "eject": "react-scripts eject"
     },


### PR DESCRIPTION
This should stop netlify builds from failing when there are warnings in the build