### PR TITLE
Fix perf issues and update stats when date update

### DIFF
--- a/packages/api/src/utils/countryISO.ts
+++ b/packages/api/src/utils/countryISO.ts
@@ -1,3 +1,4 @@
+// @ts-ignore
 import CountryLookup from 'country-code-lookup';
 import { Country } from 'src/country/country_types';
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -69,6 +69,7 @@
         "husky": ">=4",
         "lint-staged": ">=10",
         "prettier": "^2.1.1",
+        "react-query-devtools": "^2.6.1",
         "typescript-plugin-styled-components": "^1.4.4"
     },
     "husky": {

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { BrowserRouter, Switch, Route, Redirect } from 'react-router-dom';
 import AppLayout from './components/Layout';
 import Routes from './Routes';
+import { ReactQueryDevtools } from 'react-query-devtools';
 
 import { QueryCache, ReactQueryCacheProvider } from 'react-query';
 
@@ -41,6 +42,7 @@ function App() {
                     </Switch>
                 </Shell>
             </BrowserRouter>
+            <ReactQueryDevtools initialIsOpen />
         </ReactQueryCacheProvider>
     );
 }

--- a/packages/frontend/src/components/DateSlider.tsx
+++ b/packages/frontend/src/components/DateSlider.tsx
@@ -31,8 +31,8 @@ const DateSlider = ({ dates, selectedDate, onUpdate }: DateSliderProps) => {
     const dimensions = useResizeObserver(wrapperRef) || { width: 0, height: 0 };
     const sliderRef = useRef<SVGSVGElement | null>();
     const timer = useRef<number>();
-    const startDate = dates[0];
-    const endDate = dates[dates.length - 1];
+    const startDate = dates[0] || new Date();
+    const endDate = dates[dates.length - 1] || new Date();
     const { width } = dimensions || wrapperRef.current?.getBoundingClientRect();
 
     const targetValue = width - margin.right;
@@ -155,7 +155,11 @@ const DateSlider = ({ dates, selectedDate, onUpdate }: DateSliderProps) => {
                 setCurrentValue((prev) => {
                     const newValue =
                         (prev ? prev : 0) + targetValue / dates.length;
-                    if (newValue > targetValue) {
+                    const isSameDay = moment(xAxis.invert(prev || 0)).isSame(
+                        xAxis.invert(newValue),
+                        'day'
+                    );
+                    if (isSameDay || newValue > targetValue) {
                         // Stop play when reach end
                         setIsMoving(false);
                         if (timer.current) {
@@ -163,7 +167,6 @@ const DateSlider = ({ dates, selectedDate, onUpdate }: DateSliderProps) => {
                         }
                         return 0;
                     }
-
                     return newValue;
                 });
             };
@@ -174,7 +177,7 @@ const DateSlider = ({ dates, selectedDate, onUpdate }: DateSliderProps) => {
                 timer.current = setInterval(step, 300);
             }
         },
-        [targetValue, dates]
+        [targetValue, dates, xAxis]
     );
 
     return (

--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -4,13 +4,22 @@ import styled from 'styled-components';
 import AppMenu from './AppMenu';
 import HeaderRightControl from './header/HeaderRightControl';
 import HeaderLeftControl from './header/HeaderLeftControl';
+import useQueryParams from '../hooks/useQueryParams';
+import QueryParamsContext from './QueryParamsContext';
 
 const { Header, Sider, Content } = Layout;
 
 const AppLayout: FunctionComponent = ({ children }) => {
     const [navCollapsed, setNavCollapsed] = useState(false);
     const [showDrawer, setDrawer] = useState(false);
-
+    const {
+        country,
+        updateCountry,
+        dataType,
+        category,
+        updateQuery,
+        selectedDate,
+    } = useQueryParams();
     return (
         <Layout style={{ minHeight: '100vh' }}>
             <Sider
@@ -33,13 +42,31 @@ const AppLayout: FunctionComponent = ({ children }) => {
             <Main>
                 <StyledHeader>
                     <Row justify="space-between" align="middle">
-                        <HeaderLeftControl />
+                        <HeaderLeftControl
+                            dataType={dataType}
+                            updateQuery={updateQuery}
+                        />
                         <HeaderRightControl
                             openDrawer={() => setDrawer(true)}
+                            country={country}
+                            updateCountry={updateCountry}
                         />
                     </Row>
                 </StyledHeader>
-                <Content>{children}</Content>
+                <Content>
+                    <QueryParamsContext.Provider
+                        value={{
+                            country,
+                            updateCountry,
+                            dataType,
+                            category,
+                            updateQuery,
+                            selectedDate,
+                        }}
+                    >
+                        {children}
+                    </QueryParamsContext.Provider>
+                </Content>
             </Main>
         </Layout>
     );

--- a/packages/frontend/src/components/QueryParamsContext.tsx
+++ b/packages/frontend/src/components/QueryParamsContext.tsx
@@ -1,0 +1,25 @@
+import { noop } from 'lodash';
+import { Moment } from 'moment';
+import { createContext } from 'react';
+import { SeachQueryKey, SearchQueryValue } from '../hooks/useQueryParams';
+import { Category, DataType } from '../types';
+
+interface QueryParamsContextProps {
+    country: string;
+    updateCountry: (country?: string) => void;
+    selectedDate?: Moment;
+    updateQuery: (key: SeachQueryKey, value: SearchQueryValue) => void;
+    dataType: DataType;
+    category: Category;
+}
+
+const QueryParamsContext = createContext<QueryParamsContextProps>({
+    country: '',
+    updateCountry: noop,
+    selectedDate: undefined,
+    updateQuery: noop,
+    dataType: 'cumulative' as DataType,
+    category: 'confirmed' as Category,
+});
+
+export default QueryParamsContext;

--- a/packages/frontend/src/components/StatsBar.tsx
+++ b/packages/frontend/src/components/StatsBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Card, Skeleton, Statistic } from 'antd';
+import { Alert, Card, Skeleton, Statistic } from 'antd';
 import { Category, DataType, StatsBarItem } from '../types';
 import styled from 'styled-components';
 import { getCategories } from '../helper';
@@ -18,15 +18,17 @@ const StatsBar: React.FC<StatsBarProps> = ({
     category,
     selectCategory,
     data,
-    loading
+    loading,
 }) => {
     const items: StatsBarItem[] = getCategories(dataType);
-
+    if (data === undefined) {
+        return <StyledAlert message="There is no data" type="error" />;
+    }
     return (
         <Container>
-            {items.map(column => {
+            {items.map((column) => {
                 return (
-                    <Skeleton active loading={data === undefined || loading}>
+                    <Skeleton active loading={loading} key={column.category}>
                         <StyledCard
                             onClick={() => {
                                 selectCategory(column.category);
@@ -48,6 +50,10 @@ const StatsBar: React.FC<StatsBarProps> = ({
     );
 };
 
+const StyledAlert = styled(Alert)`
+    margin: 0 20px;
+`;
+
 const Container = styled.div`
     display: flex;
     justify-content: space-between;
@@ -55,7 +61,7 @@ const Container = styled.div`
 const StyledCard = styled(Card)<{ selected: boolean }>`
     flex: 1 0 0px;
     margin: 10px;
-    ${props =>
+    ${(props) =>
         props.selected &&
         `
     font-weight: bold;

--- a/packages/frontend/src/components/header/HeaderLeftControl.tsx
+++ b/packages/frontend/src/components/header/HeaderLeftControl.tsx
@@ -1,15 +1,21 @@
 import React from 'react';
-import { Row, Col, DatePicker, Select } from 'antd';
+import { Row, Col, Select } from 'antd';
 import styled from 'styled-components';
-import useQueryParams from '../../hooks/useQueryParams';
+import { SeachQueryKey, SearchQueryValue } from '../../hooks/useQueryParams';
 import { DataType } from '../../types';
-import { Moment } from 'moment';
 import { useLocation } from 'react-router-dom';
 import { ABOUT_PATH, FORECAST_PATH } from '../../Routes';
 const { Option } = Select;
 
-const HeaderLeftControl = () => {
-    const { dataType, updateQuery, selectedDate } = useQueryParams();
+interface HeaderLeftControlProps {
+    dataType: DataType;
+    updateQuery: (key: SeachQueryKey, value: SearchQueryValue) => void;
+}
+
+const HeaderLeftControl = ({
+    dataType,
+    updateQuery,
+}: HeaderLeftControlProps) => {
     const { pathname } = useLocation();
     const isHome = pathname !== FORECAST_PATH && pathname !== ABOUT_PATH;
     return (
@@ -27,14 +33,6 @@ const HeaderLeftControl = () => {
                         <Option value="cumulative">Cumulative</Option>
                         <Option value="daily">Daily</Option>
                     </Select>
-                    <Text>As of:</Text>
-                    <DatePicker
-                        bordered={false}
-                        value={selectedDate}
-                        onChange={(date: Moment | null) =>
-                            updateQuery('selectedDate', date)
-                        }
-                    />
                 </Row>
             )}
         </Col>

--- a/packages/frontend/src/components/header/HeaderRightControl.tsx
+++ b/packages/frontend/src/components/header/HeaderRightControl.tsx
@@ -3,16 +3,20 @@ import { Tooltip, Button, Row, Col } from 'antd';
 import { MenuUnfoldOutlined } from '@ant-design/icons';
 import { CountryMenu } from '../CountryMenu';
 import LanguagePanel from '../LanguagePanel';
-import useQueryParams from '../../hooks/useQueryParams';
 import { useLocation } from 'react-router-dom';
 import { ABOUT_PATH } from '../../Routes';
 
 interface HeaderRightControlProps {
     openDrawer: () => void;
+    country: string;
+    updateCountry: (country: string) => void;
 }
 
-const HeaderRightControl = ({ openDrawer }: HeaderRightControlProps) => {
-    const { country, updateCountry } = useQueryParams();
+const HeaderRightControl = ({
+    openDrawer,
+    country,
+    updateCountry,
+}: HeaderRightControlProps) => {
     const { pathname } = useLocation();
     const isNotAbout = pathname !== ABOUT_PATH;
 

--- a/packages/frontend/src/helper.ts
+++ b/packages/frontend/src/helper.ts
@@ -4,7 +4,7 @@ import { GREEN, GREY, RED } from './colors';
 import { CountryTrend } from './hooks/useCountryTrends';
 
 export const numberFormatter = new Intl.NumberFormat('en-US', {
-    maximumFractionDigits: 1
+    maximumFractionDigits: 1,
 });
 
 export const abbreviateNumber = (num: number) => {
@@ -18,10 +18,13 @@ export const abbreviateNumber = (num: number) => {
 };
 
 export const getStatistic = (
-    data: CountryTrend,
     type: DataType,
-    category: Category
+    category: Category,
+    data?: CountryTrend
 ) => {
+    if (!data) {
+        return 0;
+    }
     switch (category) {
         case 'confirmed':
             return type === 'daily' ? data.new_case : data.confirmed;
@@ -32,28 +35,6 @@ export const getStatistic = (
         default:
             return 0;
     }
-};
-
-export const findTrendData = (
-    timeseries: CountryTrend[],
-    date: Date
-): CountryTrend => {
-    const trendData = timeseries?.find(item =>
-        moment(date).isSame(moment(item.date), 'day')
-    );
-
-    return (
-        trendData || {
-            date: '',
-            deaths: 0,
-            confirmed: 0,
-            recoveries: 0,
-            new_deaths: 0,
-            new_case: 0,
-            new_recoveries: 0,
-            days_since_first_case: 0
-        }
-    );
 };
 
 export const getColor = (category: Category) => {
@@ -77,38 +58,38 @@ export const getCategories = (dataType: DataType): StatsBarItem[] =>
                   label: 'Confirmed',
                   value: 'confirmed',
                   category: 'confirmed',
-                  color: RED
+                  color: RED,
               },
               {
                   label: 'Recovered',
                   value: 'recoveries',
                   category: 'recoveries',
-                  color: GREEN
+                  color: GREEN,
               },
               {
                   label: 'Deaths',
                   value: 'deaths',
                   category: 'deaths',
-                  color: GREY
-              }
+                  color: GREY,
+              },
           ]
         : [
               {
                   label: 'New Cases',
                   value: 'new_case',
                   category: 'confirmed',
-                  color: RED
+                  color: RED,
               },
               {
                   label: 'New Recoveries',
                   value: 'new_recoveries',
                   category: 'recoveries',
-                  color: GREEN
+                  color: GREEN,
               },
               {
                   label: 'New Deaths',
                   value: 'new_deaths',
                   category: 'deaths',
-                  color: GREY
-              }
+                  color: GREY,
+              },
           ];

--- a/packages/frontend/src/hooks/useCountryTrends.ts
+++ b/packages/frontend/src/hooks/useCountryTrends.ts
@@ -14,9 +14,12 @@ export interface CountryTrend {
 export type CountryTrends = { [k in string]: CountryTrend[] };
 
 const getTrendForCountry = async (_: any, country: string | undefined) => {
+    if (!country) {
+        // TODO: fetch aggregate countries trend
+        return [];
+    }
     const controller = new AbortController();
     const { signal } = controller;
-
     const promise = fetch(`/api/country/${country}/trends`, { signal });
     // Cancel the request if React Query calls the `promise.cancel` method
     (promise as any).cancel = () => controller.abort();
@@ -31,12 +34,8 @@ export function useCountryTrends(country: string | undefined) {
         ['countryTrend', country],
         getTrendForCountry,
         {
-            enabled: country,
             initialData: [],
+            initialStale: true,
         }
     );
-}
-
-export function useAllCountryTrends() {
-    return useQuery<CountryTrends>(['countryTrend'], getTrendForCountry);
 }

--- a/packages/frontend/src/hooks/useQueryParams.ts
+++ b/packages/frontend/src/hooks/useQueryParams.ts
@@ -5,8 +5,8 @@ import qs from 'query-string';
 import { COUNTRY_PATH } from '../Routes';
 import moment, { Moment } from 'moment';
 
-type SeachQueryKey = 'selectedDate' | 'dataType' | 'category';
-type SearchQueryValue = Moment | DataType | Category | null;
+export type SeachQueryKey = 'selectedDate' | 'dataType' | 'category';
+export type SearchQueryValue = Moment | DataType | Category | null;
 
 const useQueryParams = () => {
     const { country } = useParams<CountryParam>();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1229,6 +1229,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.10.5":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.1.tgz#b4116a6b6711d010b2dad3b7b6e43bf1b9954740"
+  integrity sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.3.3", "@babel/template@^7.4.0", "@babel/template@^7.8.6":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -11361,6 +11368,14 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+match-sorter@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-4.2.1.tgz#575b4b3737185ba9518b67612b66877ea0b37358"
+  integrity sha512-s+3h9TiZU9U1pWhIERHf8/f4LmBN6IXaRgo2CI17+XGByGS1GvG5VvXK9pcGyCjGe3WM3mSYRC3ipGrd5UEVgw==
+  dependencies:
+    "@babel/runtime" "^7.10.5"
+    remove-accents "0.4.2"
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -14328,6 +14343,13 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
+react-query-devtools@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/react-query-devtools/-/react-query-devtools-2.6.1.tgz#ccb544d1d63bfc003b851424583f5d5c85fad6d1"
+  integrity sha512-qQX7MStNIZnRzDDnWepQmBG7fn7+U4AhxVpm1Kc1smaZIUEmgW8Jt8zzCutgRbcfNbJrbGi2EhRxE5BuuhvBmg==
+  dependencies:
+    match-sorter "^4.1.0"
+
 react-query@^2.23.0:
   version "2.23.0"
   resolved "https://registry.yarnpkg.com/react-query/-/react-query-2.23.0.tgz#9f9552a30380dfc1da2c165b5011465a78128ace"
@@ -14754,6 +14776,11 @@ relateurl@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=
+
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U=
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
1. Perf Improvement: 
- Remove high cost calculations, 
- Remove unnecessary re-render dependencies. 
- Move the update query params into a context so we can share some methods to update url in children

2. When date is updated, stats will also change. 
![ezgif com-gif-maker](https://user-images.githubusercontent.com/14168589/97825080-adfcf480-1c8b-11eb-9c6d-585f2f89891e.gif)


3. Remove the date picker in the header to make sure the small mobile experience is good.
4. Show an error message when there is no country selected (temporary solution now since we don't have summary data) and  handle cases when someone click an area there is no data. 

![image](https://user-images.githubusercontent.com/14168589/97824713-af79ed00-1c8a-11eb-86ac-bd411a38f733.png)

5. Fix the map missing the selected style after we switch to use iso. (we still need to fix the data show in the map)

![image](https://user-images.githubusercontent.com/14168589/97825136-dab10c00-1c8b-11eb-9aaf-1517c09c478c.png)
