### PR TITLE
Format the per 100k data to integer

### DIFF
--- a/packages/api/src/utils/countryISO.ts
+++ b/packages/api/src/utils/countryISO.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import CountryLookup from 'country-code-lookup';
 import { Country } from 'src/country/country_types';
 

--- a/packages/frontend/src/components/Trend.tsx
+++ b/packages/frontend/src/components/Trend.tsx
@@ -16,6 +16,8 @@ interface TrendProps {
     allDates: Date[];
 }
 
+const safeFormatInteger = (num: number): number => (num ? Math.round(num) : 0);
+
 const Trend = ({
     trendData,
     selectedDate,
@@ -65,14 +67,18 @@ const Trend = ({
         if (populartion && per100K) {
             const multiplier = (1 / populartion) * 100000;
             return trendData.map((item) => ({
-                confirmed: item.confirmed * multiplier,
+                confirmed: safeFormatInteger(item.confirmed * multiplier),
                 date: item.date,
-                deaths: item.deaths * multiplier,
-                new_case: item.new_case * multiplier,
-                new_deaths: item.new_deaths * multiplier,
-                new_recoveries: item.new_recoveries * multiplier,
-                recoveries: item.recoveries * multiplier,
-                days_since_first_case: item.days_since_first_case,
+                deaths: safeFormatInteger(item.deaths * multiplier),
+                new_case: safeFormatInteger(item.new_case * multiplier),
+                new_deaths: safeFormatInteger(item.new_deaths * multiplier),
+                new_recoveries: safeFormatInteger(
+                    item.new_recoveries * multiplier
+                ),
+                recoveries: safeFormatInteger(item.recoveries * multiplier),
+                days_since_first_case: safeFormatInteger(
+                    item.days_since_first_case
+                ),
             }));
         }
         return trendData;


### PR DESCRIPTION
Now we have the real popular of each country, which making the per 100k number have many decimals:

![image](https://user-images.githubusercontent.com/14168589/97903555-396a9a00-1d0d-11eb-903c-6f0f78ff0ac2.png)

This MR is to format that number.

Also. looks like we don't need "// @ts-ignore" after that PR.