### PR TITLE
Make the whole page responsive and add a toggle in header

### DIFF
--- a/packages/frontend/src/components/CountryMenu.tsx
+++ b/packages/frontend/src/components/CountryMenu.tsx
@@ -9,7 +9,7 @@ interface CountryMenuProps {
 
 export function CountryMenu({
     selectedCountry,
-    onCountrySelected
+    onCountrySelected,
 }: CountryMenuProps) {
     const { data: countries, isFetching, error } = useAvailableCountries();
 
@@ -27,7 +27,7 @@ export function CountryMenu({
         <Select
             showSearch
             value={selectedCountry}
-            style={{ width: 150 }}
+            style={{ width: 130 }}
             onSelect={handleCountryChange}
             bordered={false}
             placeholder="select a country"

--- a/packages/frontend/src/components/DateSlider.tsx
+++ b/packages/frontend/src/components/DateSlider.tsx
@@ -58,6 +58,7 @@ const DateSlider = ({ dates, selectedDate, onUpdate }: DateSliderProps) => {
 
     const drawChart = useCallback(() => {
         const svg = d3.select(sliderRef.current) as any;
+        const tickNumber = Math.min(10, Math.round((width - 130) / 60));
         svg.attr('width', width).attr('height', height);
         svg.selectAll('.ticks').remove();
         svg.selectAll('.handle').remove();
@@ -98,7 +99,7 @@ const DateSlider = ({ dates, selectedDate, onUpdate }: DateSliderProps) => {
             .attr('class', 'ticks')
             .attr('transform', 'translate(0,' + 18 + ')')
             .selectAll('text')
-            .data(xAxis.ticks(10))
+            .data(xAxis.ticks(tickNumber))
             .enter()
             .append('text')
             .attr('x', xAxis)

--- a/packages/frontend/src/components/Home.tsx
+++ b/packages/frontend/src/components/Home.tsx
@@ -122,7 +122,7 @@ const Home = () => {
                 selectedDate={selectedDate}
             />
             <Row gutter={[16, 16]}>
-                <Col md={24} lg={12}>
+                <Col xs={24} md={24} lg={12}>
                     <StatsBar
                         dataType={dataType}
                         category={category}
@@ -141,7 +141,7 @@ const Home = () => {
                         loading={isLoading}
                     />
                 </Col>
-                <Col md={24} lg={12}>
+                <Col xs={24} md={24} lg={12}>
                     <Trend
                         trendData={currentCountryTrends}
                         allDates={dates}

--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -79,7 +79,7 @@ const StyledHeader = styled(Header)`
     padding: 0 16px;
     line-height: 48px;
     &.ant-layout-header {
-        height: 48px;
+        height: auto;
     }
 `;
 

--- a/packages/frontend/src/components/StatsBar.tsx
+++ b/packages/frontend/src/components/StatsBar.tsx
@@ -44,7 +44,10 @@ const StatsBar: React.FC<StatsBarProps> = ({
                                         : (data[column.value] as number)
                                 }
                                 precision={0}
-                                valueStyle={{ color: column.color }}
+                                valueStyle={{
+                                    color: column.color,
+                                    fontSize: '120%',
+                                }}
                             />
                         </StyledCard>
                     </Skeleton>
@@ -63,7 +66,7 @@ const Container = styled.div`
     justify-content: space-between;
 `;
 const StyledCard = styled(Card)<{ selected: boolean }>`
-    flex: 1 0 0px;
+    flex: 1 1 30%;
     margin: 10px;
     ${(props) =>
         props.selected &&
@@ -72,6 +75,9 @@ const StyledCard = styled(Card)<{ selected: boolean }>`
   `};
     &:hover {
         cursor: pointer;
+    }
+    > div {
+        padding: min(6%, 24px);
     }
 `;
 export default StatsBar;

--- a/packages/frontend/src/components/Timeseries.tsx
+++ b/packages/frontend/src/components/Timeseries.tsx
@@ -26,6 +26,7 @@ import { Category, DataType, StatsBarItem } from '../types';
 import { GREEN, GREY, RED, BLUE } from '../colors';
 import { CountryTrend } from '../hooks/useCountryTrends';
 import moment from 'moment';
+import { Statistic } from 'antd';
 
 // Chart margins
 const margin = { top: 15, right: 35, bottom: 25, left: 25 };
@@ -462,10 +463,35 @@ const Timeseries = ({
                                         {formatDateToStr(highlightedDate)}
                                     </h5>
                                     <div className="stats-bottom">
-                                        <h2>{highlight}</h2>
+                                        <h2>
+                                            <Statistic
+                                                value={highlight}
+                                                precision={0}
+                                                valueStyle={{
+                                                    color: getStatColor(
+                                                        category,
+                                                        !!isPrediction
+                                                    ),
+                                                }}
+                                            />
+                                        </h2>
                                         <h6>
-                                            {delta && delta > 0 ? '+' : ''}
-                                            {delta}
+                                            <Statistic
+                                                value={delta}
+                                                prefix={
+                                                    delta && delta > 0
+                                                        ? '+'
+                                                        : ''
+                                                }
+                                                precision={0}
+                                                valueStyle={{
+                                                    color: getStatColor(
+                                                        category,
+                                                        !!isPrediction
+                                                    ),
+                                                    fontSize: 10,
+                                                }}
+                                            />
                                         </h6>
                                     </div>
                                 </div>
@@ -489,6 +515,18 @@ const Timeseries = ({
 };
 
 export default Timeseries;
+
+const getStatColor = (category: Category, isPrediction: boolean) => {
+    switch (category) {
+        case 'confirmed':
+            return isPrediction ? BLUE : RED;
+        case 'deaths':
+            return GREY;
+        case 'recoveries':
+        default:
+            return GREEN;
+    }
+};
 
 const Wrapper = styled.div`
     position: relative;

--- a/packages/frontend/src/components/africa-map/AfricaMap.tsx
+++ b/packages/frontend/src/components/africa-map/AfricaMap.tsx
@@ -273,7 +273,10 @@ const AfricaMap: React.FC<AfricaMapProps> = ({
             .attr('width', null)
             .attr('height', null);
 
-        svgParent.style('padding-bottom', calcString);
+        const isIE = window.navigator.userAgent?.indexOf('MSIE ') > 0;
+        if (isIE) {
+            svgParent.style('padding-bottom', calcString);
+        }
     };
 
     // Set up onClick handler

--- a/packages/frontend/src/components/header/HeaderLeftControl.tsx
+++ b/packages/frontend/src/components/header/HeaderLeftControl.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { Row, Col, Select } from 'antd';
+import { Row, Col, Select, Switch } from 'antd';
 import styled from 'styled-components';
 import { SeachQueryKey, SearchQueryValue } from '../../hooks/useQueryParams';
 import { DataType } from '../../types';
 import { useLocation } from 'react-router-dom';
 import { ABOUT_PATH } from '../../Routes';
+import { CloseOutlined, CheckOutlined } from '@ant-design/icons';
 const { Option } = Select;
 
 interface HeaderLeftControlProps {
@@ -19,10 +20,9 @@ const HeaderLeftControl = ({
     const { pathname } = useLocation();
     const isHome = pathname !== ABOUT_PATH;
     return (
-        <Col span={12}>
+        <Col xs={24} md={12} lg={12}>
             {isHome && (
                 <Row align="middle">
-                    <Text>Show</Text>
                     <Select
                         defaultValue={dataType}
                         style={{ width: 120, textAlign: 'left' }}
@@ -33,6 +33,11 @@ const HeaderLeftControl = ({
                         <Option value="cumulative">Cumulative</Option>
                         <Option value="daily">Daily</Option>
                     </Select>
+                    <Text>Region</Text>
+                    <Switch
+                        checkedChildren={<CheckOutlined />}
+                        defaultChecked
+                    />
                 </Row>
             )}
         </Col>

--- a/packages/frontend/src/components/header/HeaderRightControl.tsx
+++ b/packages/frontend/src/components/header/HeaderRightControl.tsx
@@ -21,7 +21,7 @@ const HeaderRightControl = ({
     const isNotAbout = pathname !== ABOUT_PATH;
 
     return (
-        <Col span={12}>
+        <Col xs={24} md={12} lg={12}>
             <Row justify="end" align="middle">
                 {isNotAbout && (
                     <CountryMenu


### PR DESCRIPTION
Before, in smaller screen:
1. The header is too busy to put all content
2. The time slider can't take all ticks in small screen.
3. The Africa map has a big gap below.
4. The stats won't be able to show all three.

![image](https://user-images.githubusercontent.com/14168589/101292669-01101d00-37df-11eb-96dc-349fcab42756.png)


Now:

![image](https://user-images.githubusercontent.com/14168589/101292640-ca3a0700-37de-11eb-92ac-80d7f5a6e04b.png)

Also, fix 

- the tooltip hover with false problem.
- The timeline stats should add commas for statistics show. 