### PR TITLE
Update colors for color-blindness

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -24,6 +24,7 @@
         "i18next-browser-languagedetector": "^6.0.1",
         "lodash": "^4.17.20",
         "moment": "^2.29.0",
+        "polished": "^4.0.5",
         "query-string": "^6.13.2",
         "react": "^16.13.1",
         "react-dom": "^16.13.1",

--- a/packages/frontend/src/colors.ts
+++ b/packages/frontend/src/colors.ts
@@ -1,11 +1,17 @@
-export const LIGHT_GREEN = '#67b87b';
-export const GREEN = '#28a745';
+// Color palette https://coolors.co/605ca8-51a3a3-f79824-a22c29-04724d
 export const WHITE = '#eaeaea';
 export const LIGHT_GREY = '#e2e2e2';
 export const GREY = '#7a7a7a';
 export const DARK_GREY = '#414141';
-export const LIGHT_RED = '#ee6161';
-export const RED = '#f80000';
-export const LIGHT_BLUE = '#add8e6';
-export const BLUE = '#1890ff';
 export const BLACK = '#000000';
+
+export const LIGHT_PURPLE = '#613b6b';
+export const PURPLE = '#4c1f56';
+export const LIGHT_BLUE = '#68a7e3';
+export const BLUE = '#3C91E6';
+export const LIGHT_ORANGE = '#f6c588';
+export const ORANGE = '#f79824ff';
+export const LIGHT_RED = '#D65E5C';
+export const RED = '#a22c29ff';
+export const LIGHT_GREEN = '#9fcb42';
+export const GREEN = '#7FB800';

--- a/packages/frontend/src/components/Timeseries.tsx
+++ b/packages/frontend/src/components/Timeseries.tsx
@@ -6,7 +6,7 @@ import {
     formatDateToStr,
     getCategories,
     getColor,
-    getStatistic,
+    getStatistic
 } from '../helper';
 import styled from 'styled-components';
 import { bisector } from 'd3-array';
@@ -20,14 +20,15 @@ import React, {
     useEffect,
     useMemo,
     useRef,
-    useState,
+    useState
 } from 'react';
 import { Category, DataType, StatsBarItem } from '../types';
-import { GREEN, GREY, RED, BLUE } from '../colors';
+import { GREY, RED, BLUE, ORANGE, LIGHT_ORANGE } from '../colors';
 import { CountryTrend } from '../hooks/useCountryTrends';
 import moment from 'moment';
 import { Statistic } from 'antd';
 import { useTranslation } from 'react-i18next';
+import { transparentize } from 'polished';
 
 // Chart margins
 const margin = { top: 15, right: 35, bottom: 25, left: 25 };
@@ -48,7 +49,7 @@ const Timeseries = ({
     timeseries,
     dates,
     dataType,
-    isLog,
+    isLog
 }: TimeseriesProps) => {
     const { t } = useTranslation();
     const refs = useRef<(SVGSVGElement | null)[]>([]);
@@ -60,12 +61,12 @@ const Timeseries = ({
     );
 
     const categories: StatsBarItem[] = useMemo(() => getCategories(dataType), [
-        dataType,
+        dataType
     ]);
 
     const timeseriesMapper = useMemo(() => {
         const mapper: TimeseriesMapper = {};
-        timeseries.forEach((item) => {
+        timeseries.forEach(item => {
             const key = moment(item.date).valueOf();
             mapper[key] = item;
         });
@@ -117,14 +118,14 @@ const Timeseries = ({
             g.attr('class', 'x-axis').call(
                 axisBottom(xScale)
                     .ticks(numTicksX)
-                    .tickFormat((date) => formatter(date as Date))
+                    .tickFormat(date => formatter(date as Date))
             );
 
         const yAxis = (g: any, yScale: AxisScale<number>) =>
             g.attr('class', 'y-axis').call(
                 axisRight(yScale)
                     .ticks(4)
-                    .tickFormat((num) => abbreviateNumber(num))
+                    .tickFormat(num => abbreviateNumber(num))
                     .tickPadding(4)
             );
 
@@ -141,7 +142,7 @@ const Timeseries = ({
                     .clamp(true)
                     .domain([
                         Math.max(1, minTrend),
-                        Math.max(10, yBufferTop * maxTrend),
+                        Math.max(10, yBufferTop * maxTrend)
                     ])
                     .nice()
                     .range([chartBottom, margin.top]);
@@ -161,7 +162,7 @@ const Timeseries = ({
             const xm = pointer(res)[0];
             const date = xScale.invert(xm);
             if (date && dates.length > 0) {
-                const bisectDate = bisector((date) => date).left;
+                const bisectDate = bisector(date => date).left;
                 const index = bisectDate(dates, date, 1);
                 const dateLeft = dates[index - 1];
                 const dateRight = dates[index];
@@ -182,9 +183,9 @@ const Timeseries = ({
 
         /* Begin drawing charts */
         const unpredictedDates = timeseries
-            .filter((t) => !t.isPrediction)
-            .map((t) => convertDateStrToDate(t.date));
-        const predictedTimeseries = timeseries.filter((t) => t.isPrediction);
+            .filter(t => !t.isPrediction)
+            .map(t => convertDateStrToDate(t.date));
+        const predictedTimeseries = timeseries.filter(t => t.isPrediction);
 
         refs.current.forEach((ref, i) => {
             const svg = select(ref) as any;
@@ -211,7 +212,10 @@ const Timeseries = ({
                 .selectAll('circle')
                 .data(unpredictedDates, (date: Date) => date);
 
-            circles.exit().style('fill-opacity', 0).remove();
+            circles
+                .exit()
+                .style('fill-opacity', 0)
+                .remove();
 
             circles
                 .enter()
@@ -250,8 +254,8 @@ const Timeseries = ({
                 }
                 const linePath = line()
                     .curve(curveMonotoneX)
-                    .x((date) => xScale(date as any))
-                    .y((date) =>
+                    .x(date => xScale(date as any))
+                    .y(date =>
                         yScale(
                             getStatistic(
                                 dataType,
@@ -302,15 +306,15 @@ const Timeseries = ({
                     .attr(
                         'd',
                         area()
-                            .x(function (d: any) {
+                            .x(function(d: any) {
                                 return xScale(convertDateStrToDate(d.date));
                             })
-                            .y0(function (d: any) {
+                            .y0(function(d: any) {
                                 return yScale(
                                     d.confirmed_prediction_upper + 2000
                                 );
                             })
-                            .y1(function (d: any) {
+                            .y1(function(d: any) {
                                 return yScale(
                                     d.confirmed_prediction_lower - 2000
                                 );
@@ -325,10 +329,10 @@ const Timeseries = ({
                     .attr(
                         'd',
                         line()
-                            .x(function (d: any) {
+                            .x(function(d: any) {
                                 return xScale(convertDateStrToDate(d.date));
                             })
-                            .y(function (d: any) {
+                            .y(function(d: any) {
                                 return yScale(d.confirmed_prediction);
                             })
                     );
@@ -378,12 +382,12 @@ const Timeseries = ({
         timeseriesMapper,
         dates,
         isLog,
-        categories,
+        categories
     ]);
 
     useEffect(() => {
         const barWidth = getBarWidth();
-        refs.current.forEach((ref) => {
+        refs.current.forEach(ref => {
             const svg = select(ref);
             svg.selectAll('circle').attr('r', (date: any) =>
                 date === highlightedDate ? barWidth : barWidth / 2
@@ -392,7 +396,7 @@ const Timeseries = ({
     }, [highlightedDate, getBarWidth]);
 
     const getStatisticDelta = useCallback(
-        (category) => {
+        category => {
             if (!highlightedDate) return;
             const currCount = getStatistic(
                 dataType,
@@ -402,7 +406,7 @@ const Timeseries = ({
                     : undefined
             );
             const prevDate =
-                dates[dates.findIndex((date) => date === highlightedDate) - 1];
+                dates[dates.findIndex(date => date === highlightedDate) - 1];
 
             const prevCount = getStatistic(
                 dataType,
@@ -419,7 +423,7 @@ const Timeseries = ({
 
         [0, 0, 0, 0, 0].map((element, index) => {
             styles.push({
-                animationDelay: `${index * 250}ms`,
+                animationDelay: `${index * 250}ms`
             });
             return null;
         });
@@ -459,9 +463,8 @@ const Timeseries = ({
                         >
                             {highlightedDate && (
                                 <div
-                                    className={`stats is-${category} ${
-                                        isPredictedCumulative && 'predicted'
-                                    }`}
+                                    className={`stats is-${category} ${isPredictedCumulative &&
+                                        'predicted'}`}
                                 >
                                     <h5 className="title">
                                         {t(
@@ -489,7 +492,7 @@ const Timeseries = ({
                                                     color: getStatColor(
                                                         category,
                                                         !!isPredictedCumulative
-                                                    ),
+                                                    )
                                                 }}
                                             />
                                         </h2>
@@ -512,7 +515,7 @@ const Timeseries = ({
                                                         category,
                                                         !!isPredictedCumulative
                                                     ),
-                                                    fontSize: 10,
+                                                    fontSize: 10
                                                 }}
                                             />
                                         </h6>
@@ -520,7 +523,7 @@ const Timeseries = ({
                                 </div>
                             )}
                             <svg
-                                ref={(element) => {
+                                ref={element => {
                                     refs.current[index] = element;
                                 }}
                                 preserveAspectRatio="xMidYMid meet"
@@ -542,19 +545,19 @@ export default Timeseries;
 const getStatColor = (category: Category, isPrediction: boolean) => {
     switch (category) {
         case 'confirmed':
-            return isPrediction ? BLUE : RED;
+            return isPrediction ? RED : ORANGE;
         case 'deaths':
             return GREY;
         case 'recoveries':
         default:
-            return GREEN;
+            return BLUE;
     }
 };
 
 const Wrapper = styled.div`
     position: relative;
     align-self: center;
-    background: rgba(255, 7, 58, 0.12);
+    background: ${transparentize(0.85, LIGHT_ORANGE)};
     border-radius: 5px;
     display: flex;
     position: relative;
@@ -578,10 +581,10 @@ const Wrapper = styled.div`
         path,
         .tick,
         line {
-            stroke: ${RED};
+            stroke: ${ORANGE};
         }
         path.confirmed-prediction {
-            stroke: ${BLUE};
+            stroke: ${RED};
         }
         path.confirmed-prediction-error {
             stroke: none;
@@ -592,23 +595,23 @@ const Wrapper = styled.div`
     }
 
     &.is-recoveries {
-        background: rgba(40, 167, 69, 0.12);
+        background: ${transparentize(0.85, BLUE)};
         h5.title,
         h2,
         h6 {
-            color: ${GREEN};
+            color: ${BLUE};
         }
         svg {
             path,
             .tick,
             line {
-                stroke: ${GREEN};
+                stroke: ${BLUE};
             }
         }
     }
 
     &.is-deaths {
-        background: rgba(108, 117, 125, 0.06);
+        background: ${transparentize(0.85, GREY)};
         h5.title,
         h2,
         h6 {
@@ -627,13 +630,13 @@ const Wrapper = styled.div`
         margin: 0;
         transition: all 0.15s ease-in-out;
         opacity: 0.6;
-        color: ${RED};
+        color: ${ORANGE};
         font-weight: 900;
         line-height: 10px;
     }
     h2,
     h6 {
-        color: ${RED};
+        color: ${ORANGE};
         font-weight: 400;
     }
 
@@ -645,7 +648,7 @@ const Wrapper = styled.div`
         h5.title,
         h2,
         h6 {
-            color: ${BLUE};
+            color: ${RED};
         }
     }
 `;

--- a/packages/frontend/src/components/africa-map/AfricaMap.tsx
+++ b/packages/frontend/src/components/africa-map/AfricaMap.tsx
@@ -5,7 +5,7 @@ import React, {
     useLayoutEffect,
     useMemo,
     useRef,
-    useState,
+    useState
 } from 'react';
 import * as d3 from 'd3';
 import { legendColor } from 'd3-svg-legend';
@@ -48,16 +48,17 @@ const feature = topojson.feature(topology, topology.objects.collection);
 const africaMapFeatures: MapData[] = feature.features;
 
 const colorRanges = {
-    confirmed: [colors.LIGHT_GREY, colors.LIGHT_RED, colors.RED],
-    recoveries: [colors.LIGHT_GREY, colors.LIGHT_GREEN, colors.GREEN],
-    deaths: [colors.LIGHT_GREY, colors.GREY],
+    confirmed: [colors.LIGHT_GREY, colors.LIGHT_ORANGE, colors.ORANGE],
+    confirmed_predicted: [colors.LIGHT_GREY, colors.LIGHT_RED, colors.RED],
+    recoveries: [colors.LIGHT_GREY, colors.LIGHT_BLUE, colors.BLUE],
+    deaths: [colors.LIGHT_GREY, colors.GREY]
 };
 const AfricaMap: React.FC<AfricaMapProps> = ({
     category,
     dataType,
     selectedCountry,
     onCountrySelect,
-    trendData,
+    trendData
 }) => {
     const { t } = useTranslation();
     const width = 960;
@@ -71,7 +72,7 @@ const AfricaMap: React.FC<AfricaMapProps> = ({
     );
 
     const isPrediction = Object.keys(trendData || {}).find(
-        (key) => trendData?.[key].isPrediction
+        key => trendData?.[key].isPrediction
     );
 
     const scaledTrendData = useMemo(() => {
@@ -87,7 +88,7 @@ const AfricaMap: React.FC<AfricaMapProps> = ({
         });
         // filter out null values
         Object.keys(scaled).forEach(
-            (key) => scaled[key] === undefined && delete scaled[key]
+            key => scaled[key] === undefined && delete scaled[key]
         );
         return scaled as { [key: string]: CountryTrend };
     }, [isPer100k, allCountryStats, trendData]);
@@ -137,9 +138,12 @@ const AfricaMap: React.FC<AfricaMapProps> = ({
 
         // Update colors
         if (scaledTrendData !== undefined) {
-            let colorRange = colorRanges[category] || colorRanges['deaths'];
+            const category_key = isPrediction
+                ? 'confirmed_predicted'
+                : category;
+            let colorRange = colorRanges[category_key] || colorRanges['deaths'];
 
-            let extent = d3.extent(values(scaledTrendData), (d) =>
+            let extent = d3.extent(values(scaledTrendData), d =>
                 typeof d[trendKey] === 'number' ? (d[trendKey] as number) : 0
             );
 
@@ -272,7 +276,9 @@ const AfricaMap: React.FC<AfricaMapProps> = ({
             .attr('d', path);
 
         // Create the tooltip
-        svg.append('g').attr('class', 'map-tooltip').append('rect');
+        svg.append('g')
+            .attr('class', 'map-tooltip')
+            .append('rect');
 
         /* Create a transparent country overlay. The overlay sits on top of the other elements and is used
         as the click and hover target. The lets us listen to mouse events without worrying about the
@@ -403,6 +409,7 @@ const ControlsContainer = styled.div`
 
 const Control = styled.div`
     margin-right: 10px;
+    font-size: 0.75rem;
 `;
 
 export default React.memo(AfricaMap);

--- a/packages/frontend/src/components/africa-map/getTooltipContent.ts
+++ b/packages/frontend/src/components/africa-map/getTooltipContent.ts
@@ -75,10 +75,10 @@ export const tooltipCSS = css`
         width: 100%;
 
         .confirmed {
-            color: ${colors.RED};
+            color: ${colors.ORANGE};
         }
         .recovered {
-            color: ${colors.GREEN};
+            color: ${colors.BLUE};
         }
         .deaths {
             color: ${colors.GREY};

--- a/packages/frontend/src/helper.ts
+++ b/packages/frontend/src/helper.ts
@@ -1,10 +1,10 @@
 import { Category, DataType, StatsBarItem } from './types';
 import moment from 'moment';
-import { BLUE, GREEN, GREY, RED } from './colors';
+import { BLUE, GREEN, GREY, ORANGE, RED } from './colors';
 import { CountryTrend } from './hooks/useCountryTrends';
 
 export const numberFormatter = new Intl.NumberFormat('en-US', {
-    maximumFractionDigits: 1,
+    maximumFractionDigits: 1
 });
 
 export const abbreviateNumber = (num: number) => {
@@ -49,9 +49,9 @@ const safeGet = (value?: number) => (value ? value : 0);
 export const getColor = (category: Category) => {
     switch (category) {
         case 'confirmed':
-            return RED;
+            return ORANGE;
         case 'recoveries':
-            return GREEN;
+            return BLUE;
         case 'deaths':
             return GREY;
     }
@@ -71,44 +71,44 @@ export const getCategories = (
                         label: 'Confirmed Prediction',
                         value: 'confirmed_prediction',
                         category: 'confirmed',
-                        color: BLUE,
+                        color: RED
                     }
                   : {
                         label: 'Confirmed',
                         value: 'confirmed',
                         category: 'confirmed',
-                        color: RED,
+                        color: ORANGE
                     },
               {
                   label: 'Recovered',
                   value: 'recoveries',
                   category: 'recoveries',
-                  color: GREEN,
+                  color: BLUE
               },
               {
                   label: 'Deaths',
                   value: 'deaths',
                   category: 'deaths',
-                  color: GREY,
-              },
+                  color: GREY
+              }
           ]
         : [
               {
                   label: 'New Cases',
                   value: 'new_case',
                   category: 'confirmed',
-                  color: RED,
+                  color: RED
               },
               {
                   label: 'New Recoveries',
                   value: 'new_recoveries',
                   category: 'recoveries',
-                  color: GREEN,
+                  color: GREEN
               },
               {
                   label: 'New Deaths',
                   value: 'new_deaths',
                   category: 'deaths',
-                  color: GREY,
-              },
+                  color: GREY
+              }
           ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1236,6 +1236,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.3.3", "@babel/template@^7.4.0", "@babel/template@^7.8.6":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -12910,6 +12917,13 @@ pnp-webpack-plugin@1.6.4:
   integrity sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==
   dependencies:
     ts-pnp "^1.1.6"
+
+polished@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.npmjs.org/polished/-/polished-4.0.5.tgz#3f91873c8f72dec1723b3f892f57fbb22645b23d"
+  integrity sha512-BY2+LVtOHQWBQpGN4GPAKpCdsBePOdSdHTpZegRDRCrvGPkRPTx1DEC+vGjIDPhXS7W2qiBxschnwRWTFdMZag==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 portfinder@^1.0.26:
   version "1.0.28"


### PR DESCRIPTION
Did some research and it seems like the r-shiny app is not something we want to emulate:
![image](https://user-images.githubusercontent.com/9931605/102126606-4bb21a80-3e19-11eb-9fc4-ceda4b6f989f.png)

Instead I went for orange-blue, let me know if this is ok:
![image](https://user-images.githubusercontent.com/9931605/102126667-62587180-3e19-11eb-9963-17ca18d77c38.png)
