### PR TITLE
Timeline different for forecast data

### DIFF
--- a/packages/frontend/src/components/Home.tsx
+++ b/packages/frontend/src/components/Home.tsx
@@ -9,7 +9,7 @@ import {
 import { useAllRegionTrends } from '../hooks/useRegionTrends';
 import StatsBar from './stats-bar/StatsBar';
 import Trend from './Trend';
-import { Moment } from 'moment';
+import moment, { Moment } from 'moment';
 import { convertDateStrToDate } from '../helper';
 import QueryParamsContext from '../contexts/QueryParamsContext';
 import styled from 'styled-components';
@@ -99,6 +99,19 @@ const Home = () => {
         [currentTrends]
     );
 
+    const lastNonPredictedDate: Moment | undefined = useMemo(() => {
+        if (!currentTrends || !currentTrends[0]) {
+            return undefined;
+        }
+        let lastDate = moment(currentTrends[0].date);
+        currentTrends.forEach((item) => {
+            if (lastDate.isBefore(item.date) && !item.confirmed_prediction) {
+                lastDate = moment(item.date);
+            }
+        });
+        return lastDate;
+    }, [currentTrends]);
+
     const onSelectDate = useCallback(
         (value: Moment) => {
             updateQuery('selectedDate', value);
@@ -158,6 +171,7 @@ const Home = () => {
                 dates={dates}
                 selectedDate={selectedDate}
                 onUpdate={onSelectDate}
+                lastNonPredictedDate={lastNonPredictedDate}
             />
             <HomeWrapper>
                 <Row gutter={LAYOUT_GUTTER}>

--- a/packages/frontend/src/components/Timeseries.tsx
+++ b/packages/frontend/src/components/Timeseries.tsx
@@ -402,7 +402,8 @@ const Timeseries = ({
                         isPrediction &&
                         category === 'confirmed' &&
                         dataType === 'cumulative';
-
+                    const unPredictable =
+                        isPrediction && category !== 'confirmed';
                     return (
                         <Wrapper
                             key={category}
@@ -428,7 +429,11 @@ const Timeseries = ({
                                         )}
                                     </h5>
                                     <h5 className="title">
-                                        {formatDay(highlightedDate)}
+                                        {unPredictable
+                                            ? '--'
+                                            : formatDay(highlightedDate)}
+                                        {unPredictable &&
+                                            ` (Forecast metrics are not available for "${label}")`}
                                     </h5>
 
                                     <HighlightNumber>

--- a/packages/frontend/src/components/controls/Controls.tsx
+++ b/packages/frontend/src/components/controls/Controls.tsx
@@ -10,7 +10,12 @@ const getLocalToggle = () => localStorage.getItem(SMALL_TOGGLE_KEY) === 'true';
 const updateLocalToggle = (value: string) =>
     localStorage.setItem(SMALL_TOGGLE_KEY, value);
 
-const Controls = ({ dates, selectedDate, onUpdate }: DateSliderProps) => {
+const Controls = ({
+    dates,
+    selectedDate,
+    onUpdate,
+    lastNonPredictedDate,
+}: DateSliderProps) => {
     const [showSmallToggle, setShowSmallToggle] = useState(getLocalToggle());
     const handleToggle = useCallback(() => {
         updateLocalToggle(showSmallToggle ? 'false' : 'true');
@@ -34,6 +39,7 @@ const Controls = ({ dates, selectedDate, onUpdate }: DateSliderProps) => {
                         dates={dates}
                         selectedDate={selectedDate}
                         onUpdate={onUpdate}
+                        lastNonPredictedDate={lastNonPredictedDate}
                     />
                 </DateSliderWrapper>
             </BottomControl>

--- a/packages/frontend/src/components/controls/DateSlider.tsx
+++ b/packages/frontend/src/components/controls/DateSlider.tsx
@@ -9,7 +9,7 @@ import { PauseCircleFilled, PlayCircleFilled } from '@ant-design/icons';
 import styled from 'styled-components';
 import { useResizeObserver } from '../../hooks/useResizeObserver';
 import * as d3 from 'd3';
-import moment from 'moment';
+import moment, { Moment } from 'moment';
 import { formatDay, formatMonth } from '../../utils/trendUtils';
 import { WHITE } from '../../colors';
 
@@ -22,9 +22,15 @@ export interface DateSliderProps {
     onUpdate: (value: moment.Moment) => void;
     selectedDate?: moment.Moment;
     dates: Date[];
+    lastNonPredictedDate?: Moment;
 }
 
-const DateSlider = ({ dates, selectedDate, onUpdate }: DateSliderProps) => {
+const DateSlider = ({
+    dates,
+    selectedDate,
+    onUpdate,
+    lastNonPredictedDate,
+}: DateSliderProps) => {
     const [isMoving, setIsMoving] = useState(false);
     const wrapperRef = useRef<HTMLDivElement | null>(null);
     const dimensions = useResizeObserver(wrapperRef) || { width: 0, height: 0 };
@@ -55,29 +61,101 @@ const DateSlider = ({ dates, selectedDate, onUpdate }: DateSliderProps) => {
         [xAxis]
     );
 
-    const drawChart = useCallback(() => {
+    useEffect(() => {
+        const drawChart = () => {
+            const svg = d3.select(sliderRef.current) as any;
+            const tickNumber = Math.min(10, Math.round((width - 130) / 70));
+
+            svg.attr('width', width).attr('height', height);
+            svg.selectAll('.ticks').remove();
+            svg.selectAll('.handle').remove();
+            svg.selectAll('.label').remove();
+            svg.selectAll('.circle-ticks').remove();
+
+            const slider = svg
+                .select('.slider')
+                .attr(
+                    'transform',
+                    'translate(' + margin.left + ',' + height / 2 + ')'
+                );
+
+            svg.select('.track')
+                .attr('x1', xAxis.range()[0])
+                .attr('x2', xAxis.range()[1]);
+
+            svg.select('.track-inset')
+                .attr('x1', xAxis.range()[0])
+                .attr('x2', xAxis.range()[1]);
+
+            slider
+                .insert('g', '.track-overlay')
+                .attr('class', 'ticks')
+                .attr('transform', 'translate(0,' + 10 + ')')
+                .selectAll('text')
+                .data(xAxis.ticks(tickNumber))
+                .enter()
+                .append('text')
+                .attr('x', xAxis)
+                .attr('y', 10)
+                .attr('text-anchor', 'middle')
+                .text(function (d: any) {
+                    return formatMonth(d);
+                });
+
+            slider
+
+                .insert('g', '.track-overlay')
+                .attr('class', 'circle-ticks')
+                .selectAll('circle')
+                .data(xAxis.ticks(tickNumber))
+                .enter()
+                .append('circle')
+                .attr('cx', xAxis)
+                .attr('cy', 0)
+                .attr('r', 6)
+                .attr('fill', WHITE)
+                .attr('stroke', '#ADC6FF');
+
+            slider
+                .insert('circle', '.track-overlay')
+                .attr('class', 'handle')
+                .attr('r', 6);
+
+            slider
+                .append('text')
+                .attr('class', 'label')
+                .attr('text-anchor', 'middle')
+                .attr('fill', '#0050B3')
+                .text(formatDay(startDate))
+                .attr('transform', 'translate(0,' + -15 + ')');
+
+            // Has predicted data
+            if (
+                lastNonPredictedDate &&
+                lastNonPredictedDate.isBefore(endDate, 'day')
+            ) {
+                svg.selectAll('.circle-ticks circle')
+                    .filter(function (d: any) {
+                        // find tickers that are predicted time
+                        return lastNonPredictedDate.isBefore(d, 'day');
+                    })
+                    .attr('class', 'predicted-tick')
+                    .attr('stroke-dasharray', 1);
+
+                const startPosition = xAxis(lastNonPredictedDate.toDate());
+                svg.select('.track-predicted')
+                    .attr('x', startPosition)
+                    .attr('width', xAxis.range()[1] - startPosition + 4)
+                    .attr('transform', 'translate(0,' + -5 + ')');
+            }
+        };
+        drawChart();
+    }, [xAxis, startDate, width, lastNonPredictedDate, endDate]);
+
+    // Control the postion of the selected circle
+    useEffect(() => {
         const svg = d3.select(sliderRef.current) as any;
-        const tickNumber = Math.min(10, Math.round((width - 130) / 70));
-        svg.attr('width', width).attr('height', height);
-        svg.selectAll('.ticks').remove();
-        svg.selectAll('.handle').remove();
-        svg.selectAll('.label').remove();
-        svg.selectAll('.circle-ticks').remove();
-
-        const slider = svg
-            .select('.slider')
-            .attr(
-                'transform',
-                'translate(' + margin.left + ',' + height / 2 + ')'
-            );
-
-        svg.select('.track')
-            .attr('x1', xAxis.range()[0])
-            .attr('x2', xAxis.range()[1]);
-
-        svg.select('.track-inset')
-            .attr('x1', xAxis.range()[0])
-            .attr('x2', xAxis.range()[1]);
+        const slider = svg.select('.slider');
 
         svg.select('.track-overlay')
             .attr('x1', xAxis.range()[0])
@@ -93,53 +171,7 @@ const DateSlider = ({ dates, selectedDate, onUpdate }: DateSliderProps) => {
                         onUpdate(moment(date));
                     })
             );
-
-        slider
-            .insert('g', '.track-overlay')
-            .attr('class', 'ticks')
-            .attr('transform', 'translate(0,' + 10 + ')')
-            .selectAll('text')
-            .data(xAxis.ticks(tickNumber))
-            .enter()
-            .append('text')
-            .attr('x', xAxis)
-            .attr('y', 10)
-            .attr('text-anchor', 'middle')
-            .text(function (d: any) {
-                return formatMonth(d);
-            });
-
-        slider
-
-            .insert('g', '.track-overlay')
-            .attr('class', 'circle-ticks')
-            .selectAll('circle')
-            .data(xAxis.ticks(tickNumber))
-            .enter()
-            .append('circle')
-            .attr('cx', xAxis)
-            .attr('cy', 0)
-            .attr('r', 6)
-            .attr('fill', WHITE)
-            .attr('stroke', '#ADC6FF');
-
-        slider
-            .insert('circle', '.track-overlay')
-            .attr('class', 'handle')
-            .attr('r', 6);
-
-        slider
-            .append('text')
-            .attr('class', 'label')
-            .attr('text-anchor', 'middle')
-            .attr('fill', '#0050B3')
-            .text(formatDay(startDate))
-            .attr('transform', 'translate(0,' + -15 + ')');
-    }, [xAxis, startDate, width]);
-
-    useEffect(() => {
-        drawChart();
-    }, [drawChart]);
+    }, [xAxis, onUpdate]);
 
     useEffect(() => {
         if (!selectedDate) {
@@ -215,6 +247,7 @@ const DateSlider = ({ dates, selectedDate, onUpdate }: DateSliderProps) => {
                 <g className="slider">
                     <line className="track" />
                     <line className="track-inset" />
+                    <rect className="track-predicted" rx="5" height="10" />
                     <line className="track-overlay" />
                 </g>
             </svg>
@@ -252,6 +285,13 @@ const Wrapper = styled.div`
     .track-inset,
     .track-overlay {
         stroke-linecap: round;
+    }
+
+    .track-predicted {
+        stroke: #adc6ff;
+        stroke-width: 2px;
+        stroke-dasharray: 1;
+        fill: #fff;
     }
 
     .track {


### PR DESCRIPTION
Fix the bug that select other category and then click timeline, it will switch back to confirm category.
Add different style for forecasted timeline and update the chart to include unpredictable text:

![image](https://user-images.githubusercontent.com/14168589/111174684-028b7700-857e-11eb-8fb7-d6998f414087.png)
