### PR TITLE
Hides prediction data for TZA as it's not good

### DIFF
--- a/packages/frontend/src/components/Home.tsx
+++ b/packages/frontend/src/components/Home.tsx
@@ -179,6 +179,7 @@ const Home = () => {
                 <Row style={{ height: '100%' }} gutter={LAYOUT_GUTTER}>
                     <Col xs={24} xl={12}>
                         <StatsBar
+                            selectedCountry={country}
                             dataType={dataType}
                             category={category}
                             selectCategory={(category) =>
@@ -214,6 +215,7 @@ const Home = () => {
                             dataType={dataType}
                             statsLoading={statsLoading}
                             selectedDate={selectedDate}
+                            country={country}
                         />
                     </Col>
                 </Row>

--- a/packages/frontend/src/components/Timeseries.tsx
+++ b/packages/frontend/src/components/Timeseries.tsx
@@ -47,6 +47,7 @@ interface TimeseriesProps {
     dataType: DataType;
     isLog: boolean;
     selectedDate?: Moment;
+    country?: string;
 }
 
 const Timeseries = ({
@@ -55,6 +56,7 @@ const Timeseries = ({
     dataType,
     isLog,
     selectedDate,
+    country,
 }: TimeseriesProps) => {
     const { t } = useTranslation();
     const refs = useRef<(SVGSVGElement | null)[]>([]);
@@ -511,8 +513,15 @@ const Timeseries = ({
         <>
             <div className="Timeseries">
                 {categories.map(({ category, label }, index) => {
-                    const highlight = getStatistic(dataType, category, stats);
+                    let highlight: string | number = getStatistic(
+                        dataType,
+                        category,
+                        stats
+                    );
                     const isPrediction = stats?.isPrediction;
+
+                    const isUnreliableData = country === 'TZA' && isPrediction;
+
                     const isPredictedConfirmed =
                         isPrediction && category === 'confirmed';
                     const unPredictable =
@@ -559,8 +568,10 @@ const Timeseries = ({
                                     <HighlightNumber>
                                         <Statistic
                                             value={
-                                                isPrediction &&
-                                                !isPredictedConfirmed
+                                                isUnreliableData
+                                                    ? 'Predictions for Tanzania are unreliable because of lack of data'
+                                                    : isPrediction &&
+                                                      !isPredictedConfirmed
                                                     ? '-'
                                                     : highlight
                                             }
@@ -569,22 +580,24 @@ const Timeseries = ({
                                             }}
                                         />
                                     </HighlightNumber>
-                                    <Delta>
-                                        <span>
-                                            {getDeltaText(
-                                                dataType,
-                                                category,
-                                                stats
-                                            )}
-                                        </span>
-                                        <Info>
-                                            <InfoTooltip
-                                                message={infoMessage}
-                                                top={0}
-                                                right={0}
-                                            />
-                                        </Info>
-                                    </Delta>
+                                    {!isUnreliableData && (
+                                        <Delta>
+                                            <span>
+                                                {getDeltaText(
+                                                    dataType,
+                                                    category,
+                                                    stats
+                                                )}
+                                            </span>
+                                            <Info>
+                                                <InfoTooltip
+                                                    message={infoMessage}
+                                                    top={0}
+                                                    right={0}
+                                                />
+                                            </Info>
+                                        </Delta>
+                                    )}
                                 </div>
                             )}
                             <svg

--- a/packages/frontend/src/components/Trend.tsx
+++ b/packages/frontend/src/components/Trend.tsx
@@ -12,6 +12,7 @@ interface TrendProps {
     dates: Date[];
     isLog: boolean;
     selectedDate?: Moment;
+    country: string;
 }
 
 const Trend = ({
@@ -21,6 +22,7 @@ const Trend = ({
     dataType,
     isLog,
     selectedDate,
+    country,
 }: TrendProps) => {
     return (
         <Card>
@@ -31,6 +33,7 @@ const Trend = ({
                     dates={dates}
                     isLog={isLog}
                     selectedDate={selectedDate}
+                    country={country}
                 />
             </Skeleton>
         </Card>

--- a/packages/frontend/src/components/stats-bar/StatsBar.tsx
+++ b/packages/frontend/src/components/stats-bar/StatsBar.tsx
@@ -15,6 +15,7 @@ interface StatsBarProps {
     category: Category;
     selectCategory: (category: Category) => void;
     data?: CountryTrend;
+    selectedCountry: string;
     loading?: boolean;
 }
 
@@ -24,9 +25,11 @@ const StatsBar: React.FC<StatsBarProps> = ({
     selectCategory,
     data,
     loading,
+    selectedCountry,
 }) => {
     const { t } = useTranslation();
     const items: StatsBarItem[] = getCategories(dataType, data?.isPrediction);
+
     return (
         <>
             <SmallStatsBar
@@ -59,7 +62,15 @@ const StatsBar: React.FC<StatsBarProps> = ({
                             >
                                 <Statistic
                                     title={t(column.label)}
-                                    value={value}
+                                    value={
+                                        selectedCountry === 'TZA' &&
+                                        (column.label ===
+                                            'New Cases Prediction' ||
+                                            column.label ===
+                                                'Confirmed Prediction')
+                                            ? 'No predictions'
+                                            : value
+                                    }
                                     valueStyle={{
                                         color: column.color,
                                         fontSize: '120%',

--- a/packages/frontend/src/hooks/useGLLayers.ts
+++ b/packages/frontend/src/hooks/useGLLayers.ts
@@ -60,6 +60,9 @@ export const useGLLayers = (
                 new GeoJsonLayer({
                     id: 'countries',
                     getFillColor: (f: any) => {
+                        if (f.properties.iso3 === 'TZA' && isPrediction) {
+                            return [0, 0, 0, 255];
+                        }
                         let datum = scaledData
                             ? scaledData[f.properties.iso3 as string]
                             : null;


### PR DESCRIPTION
Hides the TZA predictions data wherever it is shown 